### PR TITLE
feat: add pytest pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+-   repo: local
+    hooks:
+    -   id: pytest
+        name: pytest
+        entry: pytest
+        language: system
+        pass_filenames: false
+        always_run: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,3 +12,9 @@ dependencies = []
 
 [project.scripts]
 gadget = "gadget.cli:main"
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "pre-commit"
+]


### PR DESCRIPTION
Resolves #2.

This PR introduces a Git pre-commit hook configuration `.pre-commit-config.yaml` that automatically runs the pytest test suite before any commits are allowed.

Also updates `pyproject.toml` to support dev dependencies easily.